### PR TITLE
Move project file check in backend upgrade

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/BackendUpgrade/BackendUpgrade.cs
+++ b/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/BackendUpgrade/BackendUpgrade.cs
@@ -94,6 +94,13 @@ public class BackendUpgrade
                     appSettingsFolder = Path.Combine(projectFolder, appSettingsFolder);
                 }
 
+                if (!File.Exists(projectFile))
+                {
+                    Console.WriteLine($"Project file {projectFile} does not exist. Please supply location of project with --project [path/to/project.csproj]");
+                    Environment.Exit(1);
+                    return;
+                }
+
                 var projectChecks = new ProjectChecks.ProjectChecks(projectFile);
                 if (!projectChecks.SupportedSourceVersion())
                 {
@@ -145,12 +152,6 @@ public class BackendUpgrade
     
     static async Task<int> UpgradeProjectFile(string projectFile, string targetVersion, string targetFramework)
     {
-        if (!File.Exists(projectFile))
-        {
-            Console.WriteLine($"Project file {projectFile} does not exist. Please supply location of project with --project [path/to/project.csproj]");
-            return 1;
-        }
-
         Console.WriteLine("Trying to upgrade nuget versions in project file");
         var rewriter = new ProjectFileRewriter(projectFile, targetVersion, targetFramework);
         await rewriter.Upgrade();
@@ -174,12 +175,6 @@ public class BackendUpgrade
 
     static async Task<int> UpgradeCode(string projectFile)
     {
-        if (!File.Exists(projectFile))
-        {
-            Console.WriteLine($"Project file {projectFile} does not exist. Please supply location of project with --project [path/to/project.csproj]");
-            return 1;
-        }
-
         Console.WriteLine("Trying to upgrade references and using in code");
 
         MSBuildLocator.RegisterDefaults();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Moves the check for if the project file exists to before the `ProjectChecks.SupportedSourceVersion()` call. Apps with incorrectly specified project file now see this instead of an uncaught exception:
```
Project file /Users/bjosttveit/altinn/all-apps/dibk-tt02-hoering-og-offentlig-ettersyn/App/App.csproj does not exist. Please supply location of project with --project [path/to/project.csproj]
```

## Related Issue(s)
- closes #7

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~[ ] All tests run green~~

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
