### PR TITLE
Update upgrade-scripts for rc2

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/BackendUpgrade/BackendUpgrade.cs
+++ b/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/BackendUpgrade/BackendUpgrade.cs
@@ -24,7 +24,7 @@ public class BackendUpgrade
         var projectFileOption = new Option<string>(name: "--project", description: "The project file to read relative to --folder", getDefaultValue: () => "App/App.csproj");
         var processFileOption = new Option<string>(name: "--process", description: "The process file to read relative to --folder", getDefaultValue: () => "App/config/process/process.bpmn");
         var appSettingsFolderOption = new Option<string>(name: "--appsettings-folder", description: "The folder where the appsettings.*.json files are located", getDefaultValue: () => "App");
-        var targetVersionOption = new Option<string>(name: "--target-version", description: "The target version to upgrade to", getDefaultValue: () => "8.0.0-preview.11");
+        var targetVersionOption = new Option<string>(name: "--target-version", description: "The target version to upgrade to", getDefaultValue: () => "8.0.0-preview.16");
         var targetFrameworkOption = new Option<string>(name: "--target-framework", description: "The target dotnet framework version to upgrade to", getDefaultValue: () => "net8.0");
         var skipCsprojUpgradeOption = new Option<bool>(name: "--skip-csproj-upgrade", description: "Skip csproj file upgrade", getDefaultValue: () => false);
         var skipDockerUpgradeOption = new Option<bool>(name: "--skip-dockerfile-upgrade", description: "Skip Dockerfile upgrade", getDefaultValue: () => false);

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FrontendUpgrade/FrontendUpgrade.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FrontendUpgrade/FrontendUpgrade.cs
@@ -28,7 +28,7 @@ class FrontendUpgrade
 
     public static Command GetUpgradeCommand(Option<string> projectFolderOption)
     {
-        var targetVersionOption = new Option<string>(name: "--target-version", description: "The target version to upgrade to", getDefaultValue: () => "4.0.0-rc1");
+        var targetVersionOption = new Option<string>(name: "--target-version", description: "The target version to upgrade to", getDefaultValue: () => "4.0.0-rc2");
         var indexFileOption = new Option<string>(name: "--index-file", description: "The name of the Index.cshtml file relative to --folder", getDefaultValue: () => "App/views/Home/Index.cshtml");
         var skipIndexFileUpgradeOption = new Option<bool>(name: "--skip-index-file-upgrade", description: "Skip Index.cshtml upgrade", getDefaultValue: () => false);
         var uiFolderOption = new Option<string>(name: "--ui-folder", description: "The folder containing layout files relative to --folder", getDefaultValue: () => "App/ui/");

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutUpgrader.cs
@@ -27,7 +27,7 @@ class LayoutUpgrader
     public void Upgrade()
     {
         layoutMutator.ReadAllLayoutFiles();
-        // layoutMutator.Mutate(new AddressMutator());
+        layoutMutator.Mutate(new AddressMutator());
         layoutMutator.Mutate(new LikertMutator());
         layoutMutator.Mutate(new RepeatingGroupMutator());
         layoutMutator.Mutate(new GroupMutator());

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/PropertyCleanupMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/PropertyCleanupMutator.cs
@@ -23,8 +23,7 @@ class PropertyCleanupMutator : ILayoutMutator
             return new ErrorResult() { Message = "Unable to parse component type" };
         }
 
-        // TODO: Change AddressComponent to Address
-        var formComponentTypes = new List<string>() {"AddressComponent", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
+        var formComponentTypes = new List<string>() {"Address", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
 
         if (component.ContainsKey("componentType"))
         {

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/TriggerMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/TriggerMutator.cs
@@ -31,8 +31,7 @@ class TriggerMutator : ILayoutMutator
         }
 
         // TODO: Do we need to add standard validations to all components? Like options based components?
-        // TODO: Change AddressComponent to Address
-        var formComponentTypes = new List<string>() {"AddressComponent", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
+        var formComponentTypes = new List<string>() {"Address", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
 
         if (formComponentTypes.Contains(type))
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

App-Frontend 4-RC2 is now released. This update bumps the default targetVersions to v8-preview.16 and v4-rc2, and activates AddressComponent upgrade.