### PR TITLE
Make likert mutator idempotent

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/LikertMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/LikertMutator.cs
@@ -24,7 +24,15 @@ class LikertMutator : ILayoutMutator
         }
 
         // Delete old likert component
-        if (type == "Likert")
+        if (
+            type == "Likert"
+            && (
+                !component.TryGetPropertyValue("dataModelBindings", out var oldLikertDmbNode)
+                || oldLikertDmbNode is not JsonObject oldLikertDmbObject
+                || !oldLikertDmbObject.ContainsKey(("questions"))
+                    && !oldLikertDmbObject.ContainsKey(("answer"))
+            )
+        )
         {
             return new DeleteResult();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since the LikertMutator would delete the old Likert component (and change the Group's type to Likert), it would not be idempotent, as it would delete the new likert component if the upgrade was ran multiple times. I added a check so it will not remove an already converted Likert component. I tested running the frontend-upgrade several times against frontend-test-v3, and it seems that no additional changes are made after the first run.