### PR TITLE
Fix checkboxes type capitalization

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/PropertyCleanupMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/PropertyCleanupMutator.cs
@@ -23,7 +23,7 @@ class PropertyCleanupMutator : ILayoutMutator
             return new ErrorResult() { Message = "Unable to parse component type" };
         }
 
-        var formComponentTypes = new List<string>() {"Address", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
+        var formComponentTypes = new List<string>() {"Address", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
 
         if (component.ContainsKey("componentType"))
         {

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/TriggerMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/Mutators/TriggerMutator.cs
@@ -31,7 +31,7 @@ class TriggerMutator : ILayoutMutator
         }
 
         // TODO: Do we need to add standard validations to all components? Like options based components?
-        var formComponentTypes = new List<string>() {"Address", "CheckBoxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
+        var formComponentTypes = new List<string>() {"Address", "Checkboxes", "Custom", "Datepicker", "Dropdown", "FileUpload", "FileUploadWithTag", "Grid", "Input", "Likert", "List", "Map", "MultipleSelect", "RadioButtons", "TextArea"};
 
         if (formComponentTypes.Contains(type))
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed `CheckBoxes` to `Checkboxes`, this mistake caused dataModelBindings to get incorrectly removed from checkbox components. Tested on `frontend-test-v3`.