### PR TITLE
Add AltinnRowId to all model classes used in lists

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
+++ b/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
@@ -1,0 +1,44 @@
+using System.Xml.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Altinn.Studio.Cli.Upgrade.Backend.v7Tov8.CodeRewriters;
+
+/// <summary>
+/// Rewrites the Model classes to include Guid AltinnRowId
+/// </summary>
+public class ModelRewriter : CSharpSyntaxRewriter
+{
+    private readonly List<string> _modelsInList;
+
+    public ModelRewriter(List<string> modelsInList)
+    {
+        _modelsInList = modelsInList;
+    }
+    /// <inheritdoc/>
+    public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node)
+    {
+        if (_modelsInList.Contains(node.Identifier.Text) && !node.Members.Any(m => m is PropertyDeclarationSyntax p && p.Identifier.Text == "AltinnRowId"))
+        {
+            var altinnRowIdProperty = SyntaxFactory.ParseMemberDeclaration("""
+                [XmlAttribute("altinnRowId")]
+                [JsonPropertyName("altinnRowId")]
+                [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+                public Guid AltinnRowId { get; set; }
+            """)!.WithTrailingTrivia(SyntaxFactory.LineFeed, SyntaxFactory.LineFeed);
+
+            var altinnRowIdSpecified = SyntaxFactory.ParseMemberDeclaration("""
+                public bool AltinnRowIdSpecified()
+                {
+                    return AltinnRowId == default;
+                }
+            """)!.WithTrailingTrivia(SyntaxFactory.LineFeed, SyntaxFactory.LineFeed);
+
+
+            node = node.WithMembers(node.Members.InsertRange(0, [altinnRowIdProperty, altinnRowIdSpecified]));
+        }
+
+        return base.VisitClassDeclaration(node);
+    }
+}

--- a/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
+++ b/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
@@ -31,7 +31,7 @@ public class ModelRewriter : CSharpSyntaxRewriter
             var altinnRowIdSpecified = SyntaxFactory.ParseMemberDeclaration("""
                 public bool AltinnRowIdSpecified()
                 {
-                    return AltinnRowId == default;
+                    return AltinnRowId != default;
                 }
             """)!.WithTrailingTrivia(SyntaxFactory.LineFeed, SyntaxFactory.LineFeed);
 


### PR DESCRIPTION
For all classes in the `App/models` folder that are referenced (In the same file) in a `List<>` expression, add the `AltinnRowId` property

<img width="957" alt="Screenshot 2024-02-21 at 23 19 03" src="https://github.com/Altinn/altinn-studio-cli/assets/131616/5ef9475c-87bf-4ef9-b973-71a834e8a255">

Note that I used `[XmlAttribute]` not `[XmlElement]`, so that the xml looks like
```xml
    <nested_list altinnRowId="2d53a737-8558-45f4-a348-5543af138d80">
      <key>newKey</key>
    </nested_list>
// Not
    <nested_list>
      <altinnRowId>2d53a737-8558-45f4-a348-5543af138d80</altinnRowId>
      <key>newKey</key>
    </nested_list>
```
I don't have any good reasons, apart from that I think it looks better, makes sense and a suspicion that there might be tools that ignore attributes when dealing with data, thus making it a slightly safer option.



## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/441

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
