### PR TITLE
Ignore empty layoutset directory

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutSetRewriter/LayoutSetUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutSetRewriter/LayoutSetUpgrader.cs
@@ -144,6 +144,15 @@ class LayoutSetUpgrader
         var newLayoutsPath = Path.Combine(uiFolder, layoutSetName, "layouts");
         if (Directory.Exists(oldLayoutsPath))
         {
+            if (Directory.Exists(newLayoutsPath) && Directory.GetFileSystemEntries(newLayoutsPath).Count() == 0)
+            {
+                Directory.Delete(newLayoutsPath, false);
+            }
+            else
+            {
+                throw new Exception($"The folder {newLayoutsPath} already exists and is not empty");
+            }
+
             Directory.Move(oldLayoutsPath, newLayoutsPath);
         }
         else


### PR DESCRIPTION
When running the tool multiple times, there might be an old form layoutset folder from the previous run. This change ignores that folder if it is empty


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
