### PR TITLE
Fix tool crashing if layouts empty or new layoutset folder is missing

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FooterRewriter/FooterUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FooterRewriter/FooterUpgrader.cs
@@ -26,7 +26,7 @@ class FooterUpgrader
 
     public void Upgrade()
     {
-        var footerFile = Path.Join(uiFolder, "footer.json");
+        var footerFile = Path.Combine(uiFolder, "footer.json");
         if (File.Exists(footerFile))
         {
             var footerJson = JsonNode.Parse(File.ReadAllText(footerFile), null, new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
@@ -75,6 +75,6 @@ class FooterUpgrader
         };
 
         var footerText = footer.ToJsonString(options);
-        await File.WriteAllTextAsync(Path.Join(uiFolder, "footer.json"), footerText);
+        await File.WriteAllTextAsync(Path.Combine(uiFolder, "footer.json"), footerText);
     }
 }

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutMutator.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutMutator.cs
@@ -29,7 +29,15 @@ class LayoutMutator
         var layoutSets = Directory.GetDirectories(uiFolder);
         foreach (var layoutSet in layoutSets)
         {
-            var layoutFiles = Directory.GetFiles(Path.Join(layoutSet, "layouts"), "*.json");
+            var layoutsFolder = Path.Combine(layoutSet, "layouts");
+            if (!Directory.Exists(layoutsFolder))
+            {
+              var compactLayoutsPath = string.Join(Path.DirectorySeparatorChar, layoutSet.Split(Path.DirectorySeparatorChar)[^2..]);
+              warnings.Add($"No layouts folder found in layoutset {compactLayoutsPath}, skipping");
+              continue;
+            }
+
+            var layoutFiles = Directory.GetFiles(layoutsFolder, "*.json");
             foreach (var layoutFile in layoutFiles)
             {
                 var layoutText = File.ReadAllText(layoutFile);
@@ -37,7 +45,8 @@ class LayoutMutator
 
                 if (layoutJson is not JsonObject layoutJsonObject)
                 {
-                    warnings.Add($"Unable to parse {layoutFile} as a json object, skipping");
+                    var compactLayoutFilePath = string.Join(Path.DirectorySeparatorChar, layoutFile.Split(Path.DirectorySeparatorChar)[^3..]);
+                    warnings.Add($"Unable to parse {compactLayoutFilePath} as a json object, skipping");
                     continue;
                 }
 

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutSetRewriter/LayoutSetUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutSetRewriter/LayoutSetUpgrader.cs
@@ -144,13 +144,14 @@ class LayoutSetUpgrader
         var newLayoutsPath = Path.Combine(uiFolder, layoutSetName, "layouts");
         if (Directory.Exists(oldLayoutsPath))
         {
-            if (Directory.Exists(newLayoutsPath) && Directory.GetFileSystemEntries(newLayoutsPath).Count() == 0)
+            if (Directory.Exists(newLayoutsPath))
             {
+                if (Directory.GetFileSystemEntries(newLayoutsPath).Count() > 0)
+                {
+                    throw new Exception($"The folder {newLayoutsPath} already exists and is not empty");
+                }
+
                 Directory.Delete(newLayoutsPath, false);
-            }
-            else
-            {
-                throw new Exception($"The folder {newLayoutsPath} already exists and is not empty");
             }
 
             Directory.Move(oldLayoutsPath, newLayoutsPath);

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/SchemaRefRewriter/SchemaRefUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/SchemaRefRewriter/SchemaRefUpgrader.cs
@@ -76,7 +76,7 @@ class SchemaRefUpgrader
         }
 
         // Footer
-        var footerFile = Path.Join(uiFolder, "footer.json");
+        var footerFile = Path.Combine(uiFolder, "footer.json");
         if (File.Exists(footerFile))
         {
             var footerJson = JsonNode.Parse(File.ReadAllText(footerFile), null, new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
@@ -107,7 +107,7 @@ class SchemaRefUpgrader
         foreach (var layoutSet in layoutSets)
         {
             // Layout settings
-            var layoutSettingsFile = Path.Join(layoutSet, "Settings.json");
+            var layoutSettingsFile = Path.Combine(layoutSet, "Settings.json");
             var compactSettingsFilePath = string.Join(Path.DirectorySeparatorChar, layoutSettingsFile.Split(Path.DirectorySeparatorChar)[^2..]);
             if (File.Exists(layoutSettingsFile)) {
                 var layoutSettingsJson = JsonNode.Parse(File.ReadAllText(layoutSettingsFile), null, new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
@@ -126,22 +126,31 @@ class SchemaRefUpgrader
             }
 
             // Layout files
-            var layoutFiles = Directory.GetFiles(Path.Join(layoutSet, "layouts"), "*.json");
-            foreach (var layoutFile in layoutFiles)
+            var layoutsFolder = Path.Combine(layoutSet, "layouts");
+            if (Directory.Exists(layoutsFolder))
             {
-                var layoutJson = JsonNode.Parse(File.ReadAllText(layoutFile), null, new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
-                if (layoutJson is JsonObject layoutJsonObject)
-                {
-                    this.files.Add(layoutFile, WithSchemaRef(layoutJsonObject, layoutSchemaUri));
-                }
-                else
-                {
-                    var compactLayoutFilePath = string.Join(Path.DirectorySeparatorChar, layoutFile.Split(Path.DirectorySeparatorChar)[^3..]);
-                    warnings.Add($"Unable to parse {compactLayoutFilePath}, skipping schema ref upgrade");
-                }
+              var layoutFiles = Directory.GetFiles(layoutsFolder, "*.json");
+              foreach (var layoutFile in layoutFiles)
+              {
+                  var layoutJson = JsonNode.Parse(File.ReadAllText(layoutFile), null, new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
+                  if (layoutJson is JsonObject layoutJsonObject)
+                  {
+                      this.files.Add(layoutFile, WithSchemaRef(layoutJsonObject, layoutSchemaUri));
+                  }
+                  else
+                  {
+                      var compactLayoutFilePath = string.Join(Path.DirectorySeparatorChar, layoutFile.Split(Path.DirectorySeparatorChar)[^3..]);
+                      warnings.Add($"Unable to parse {compactLayoutFilePath}, skipping schema ref upgrade");
+                  }
+              }
+            } 
+            else 
+            {
+              var compactLayoutsPath = string.Join(Path.DirectorySeparatorChar, layoutSet.Split(Path.DirectorySeparatorChar)[^2..]);
+              warnings.Add($"No layouts folder found in layoutset {compactLayoutsPath}, skipping");
+              continue;
             }
         }
-
     }
 
     public JsonObject WithSchemaRef(JsonObject json, string schemaUrl)

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/SettingsWriter/SettingsWriter.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/SettingsWriter/SettingsWriter.cs
@@ -35,7 +35,15 @@ class SettingsCreator
             continue;
           }
 
-          var order = Directory.GetFiles(Path.Combine(layoutSet, "layouts"), "*.json").Select(f => $@"""{Path.GetFileNameWithoutExtension(f)}""").ToList();
+          var layoutsFolder = Path.Combine(layoutSet, "layouts");
+          if (!Directory.Exists(layoutsFolder))
+          {
+            var compactFilePath = string.Join(Path.DirectorySeparatorChar, layoutSet.Split(Path.DirectorySeparatorChar)[^2..]);
+            warnings.Add($"No layouts folder found in layoutset {compactFilePath}, skipping");
+            continue;
+          }
+
+          var order = Directory.GetFiles(layoutsFolder, "*.json").Select(f => $@"""{Path.GetFileNameWithoutExtension(f)}""").ToList();
 
           var layoutSettingsJsonString = $@"{{""$schema"": ""https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json"", ""pages"": {{""order"": [{string.Join(", ", order)}]}}}}";
           settingsCollection.Add(settingsFileName, JsonNode.Parse(layoutSettingsJsonString)!);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

https://github.com/Altinn/altinn-studio-cli/pull/31 throws an error if the new layout set folder is not empty (which is correct) but it also throws an error if the folder is missing, which it usually is before upgrading.

I also added some more checks for if the `layouts` folder inside of a layout set actually exists before continuing, as this caused crashes for https://altinn.studio/repos/EirikOlavHaugenSSB/ra0797-01.git. The config here is a bit weird though, it appears as if they converted to layout sets manually without deleting the old `ui/layouts` directory afterwards.

## Related Issue(s)
- https://github.com/Altinn/altinn-studio-cli/pull/31

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
