### PR TITLE
Use ShouldSerialize* instead of *Specified

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
+++ b/src/altinn-studio-cli/Upgrade/Backend/v7Tov8/CodeRewriters/ModelRewriter.cs
@@ -28,15 +28,15 @@ public class ModelRewriter : CSharpSyntaxRewriter
                 public Guid AltinnRowId { get; set; }
             """)!.WithTrailingTrivia(SyntaxFactory.LineFeed, SyntaxFactory.LineFeed);
 
-            var altinnRowIdSpecified = SyntaxFactory.ParseMemberDeclaration("""
-                public bool AltinnRowIdSpecified()
+            var altinnRowIdShouldSerialize = SyntaxFactory.ParseMemberDeclaration("""
+                public bool ShouldSerializeAltinnRowId()
                 {
                     return AltinnRowId != default;
                 }
             """)!.WithTrailingTrivia(SyntaxFactory.LineFeed, SyntaxFactory.LineFeed);
 
 
-            node = node.WithMembers(node.Members.InsertRange(0, [altinnRowIdProperty, altinnRowIdSpecified]));
+            node = node.WithMembers(node.Members.InsertRange(0, [altinnRowIdProperty, altinnRowIdShouldSerialize]));
         }
 
         return base.VisitClassDeclaration(node);


### PR DESCRIPTION
Bug discovered by @mirkoSekulic that we should use a different pattern to disable serialisation of Guid.Empty

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/12447

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
