### PR TITLE
Update default validation triggers upgrade

### DIFF
--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FrontendUpgrade/FrontendUpgrade.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/FrontendUpgrade/FrontendUpgrade.cs
@@ -39,7 +39,6 @@ class FrontendUpgrade
         var skipLayoutSetUpgradeOption = new Option<bool>(name: "--skip-layout-set-upgrade", description: "Skip layout set upgrade", getDefaultValue: () => false);
         var skipSettingsUpgradeOption = new Option<bool>(name: "--skip-settings-upgrade", description: "Skip layout settings upgrade", getDefaultValue: () => false);
         var skipLayoutUpgradeOption = new Option<bool>(name: "--skip-layout-upgrade", description: "Skip layout files upgrade", getDefaultValue: () => false);
-        var preserveDefaultTriggersOption = new Option<bool>(name: "--preserve-default-triggers", description: "Preserve default schema and component validation triggers", getDefaultValue: () => false);
         var convertGroupTitlesOption = new Option<bool>(name: "--convert-group-titles", description: "Convert 'title' in repeating groups to 'summaryTitle'", getDefaultValue: () => false);
         var skipSchemaRefUpgradeOption = new Option<bool>(name: "--skip-schema-ref-upgrade", description: "Skip schema reference upgrade", getDefaultValue: () => false);
         var skipFooterUpgradeOption = new Option<bool>(name: "--skip-footer-upgrade", description: "Skip footer upgrade", getDefaultValue: () => false);
@@ -60,7 +59,6 @@ class FrontendUpgrade
             skipLayoutSetUpgradeOption,
             skipSettingsUpgradeOption,
             skipLayoutUpgradeOption,
-            preserveDefaultTriggersOption,
             convertGroupTitlesOption,
             skipSchemaRefUpgradeOption,
             skipFooterUpgradeOption,
@@ -85,7 +83,6 @@ class FrontendUpgrade
                 var skipChecks = context.ParseResult.GetValueForOption(skipChecksOption)!;
                 var layoutSetName = context.ParseResult.GetValueForOption(layoutSetNameOption)!;
                 var receiptLayoutSetName = context.ParseResult.GetValueForOption(receiptLayoutSetNameOption)!;
-                var preserveDefaultTriggers = context.ParseResult.GetValueForOption(preserveDefaultTriggersOption)!;
                 var convertGroupTitles = context.ParseResult.GetValueForOption(convertGroupTitlesOption)!;
                 var targetVersion = context.ParseResult.GetValueForOption(targetVersionOption)!;
 
@@ -143,7 +140,7 @@ class FrontendUpgrade
                 if (!skipLayoutUpgrade && returnCode == 0)
                 {
 
-                    returnCode = await LayoutUpgrade(uiFolder, preserveDefaultTriggers, convertGroupTitles);
+                    returnCode = await LayoutUpgrade(uiFolder, convertGroupTitles);
                 }
 
                 if (!skipFooterUpgrade && returnCode == 0)
@@ -283,7 +280,7 @@ class FrontendUpgrade
         return 0;
     }
 
-    private static async Task<int> LayoutUpgrade(string uiFolder, bool preserveDefaultTriggers, bool convertGroupTitles)
+    private static async Task<int> LayoutUpgrade(string uiFolder, bool convertGroupTitles)
     {
         if (!Directory.Exists(uiFolder))
         {
@@ -297,8 +294,7 @@ class FrontendUpgrade
             return 1;
         }
 
-
-        var rewriter = new LayoutUpgrader(uiFolder, preserveDefaultTriggers, convertGroupTitles);
+        var rewriter = new LayoutUpgrader(uiFolder, convertGroupTitles);
         rewriter.Upgrade();
         await rewriter.Write();
 

--- a/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutUpgrader.cs
+++ b/src/altinn-studio-cli/Upgrade/Frontend/Fev3Tov4/LayoutRewriter/LayoutUpgrader.cs
@@ -6,13 +6,11 @@ class LayoutUpgrader
 {
     private readonly IList<string> warnings = new List<string>();
     private readonly LayoutMutator layoutMutator;
-    private readonly bool preserveDefaultTriggers;
     private readonly bool convertGroupTitles;
 
-    public LayoutUpgrader(string uiFolder, bool preserveDefaultTriggers, bool convertGroupTitles)
+    public LayoutUpgrader(string uiFolder, bool convertGroupTitles)
     {
         this.layoutMutator = new LayoutMutator(uiFolder);
-        this.preserveDefaultTriggers = preserveDefaultTriggers;
         this.convertGroupTitles = convertGroupTitles;
     }
 
@@ -31,7 +29,7 @@ class LayoutUpgrader
         layoutMutator.Mutate(new LikertMutator());
         layoutMutator.Mutate(new RepeatingGroupMutator());
         layoutMutator.Mutate(new GroupMutator());
-        layoutMutator.Mutate(new TriggerMutator(this.preserveDefaultTriggers));
+        layoutMutator.Mutate(new TriggerMutator());
         layoutMutator.Mutate(new TrbMutator(this.convertGroupTitles));
         layoutMutator.Mutate(new AttachmentListMutator());
         layoutMutator.Mutate(new PropertyCleanupMutator());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The default `showValidations` was changed in https://github.com/Altinn/app-frontend-react/pull/1893 to act more like it did in v3. As a result, we no longer need to add any `showValidations` to cover the `triggers: [validation]` case, and there is also no need for the `--preserve-default-triggers` option. Additionally, this will remove any redundant `showValidations: [AllExceptRequired]` from previous runs of the upgrade tool.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/1893

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
